### PR TITLE
Update links to point to tuto/release and to teaching_tools/README

### DIFF
--- a/geomorphology_exercises/channels_streampower_notebooks/stream_power_channels_class_notebook.ipynb
+++ b/geomorphology_exercises/channels_streampower_notebooks/stream_power_channels_class_notebook.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/master/landlab_header.png\"></a>"
+    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/release/landlab_header.png\"></a>"
    ]
   },
   {
@@ -20,7 +20,7 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a></small><br>\n",
+    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/landlab_teaching_tools/blob/master/README.md\">https://github.com/landlab/landlab_teaching_tools/blob/master/README.md</a></small><br>\n",
     "<small>For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a></small>\n",
     "<hr>"
    ]

--- a/geomorphology_exercises/drainage_density_notebooks/drainage_density_class_notebook.ipynb
+++ b/geomorphology_exercises/drainage_density_notebooks/drainage_density_class_notebook.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/master/landlab_header.png\"></a>"
+    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/release/landlab_header.png\"></a>"
    ]
   },
   {
@@ -20,7 +20,7 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a></small><br>\n",
+    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/landlab_teaching_tools/blob/master/README.md\">https://github.com/landlab/landlab_teaching_tools/blob/master/README.md</a></small><br>\n",
     "<small>For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a></small>\n",
     "<hr>"
    ]

--- a/geomorphology_exercises/hillslope_notebooks/hillslope_diffusion_class_notebook.ipynb
+++ b/geomorphology_exercises/hillslope_notebooks/hillslope_diffusion_class_notebook.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/master/landlab_header.png\"></a>"
+    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/release/landlab_header.png\"></a>"
    ]
   },
   {
@@ -21,7 +21,7 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a><br>\n",
+    "For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/landlab_teaching_tools/blob/master/README.md\">https://github.com/landlab/landlab_teaching_tools/blob/master/README.md</a><br>\n",
     "For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a>\n",
     "<hr>\n"
    ]

--- a/geomorphology_exercises/hillslope_notebooks/north_carolina_piedmont_hillslope_class_notebook.ipynb
+++ b/geomorphology_exercises/hillslope_notebooks/north_carolina_piedmont_hillslope_class_notebook.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/master/landlab_header.png\"></a>"
+    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/release/landlab_header.png\"></a>"
    ]
   },
   {
@@ -21,7 +21,7 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a><br>\n",
+    "For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/landlab_teaching_tools/blob/master/README.md\">https://github.com/landlab/landlab_teaching_tools/blob/master/README.md</a><br>\n",
     "For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a>\n",
     "<hr>\n"
    ]

--- a/surface_water_hydrology_exercises/overland_flow_notebooks/hydrograph_class_notebook.ipynb
+++ b/surface_water_hydrology_exercises/overland_flow_notebooks/hydrograph_class_notebook.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/master/landlab_header.png\"></a>"
+    "<a href=\"http://landlab.github.io\"><img style=\"float: left\" src=\"https://raw.githubusercontent.com/landlab/tutorials/release/landlab_header.png\"></a>"
    ]
   },
   {
@@ -20,7 +20,7 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/tutorials/blob/master/README.md\">https://github.com/landlab/tutorials/blob/master/README.md</a></small><br>\n",
+    "<small> For instructions on how to run an interactive IPython notebook, click here: <a href=\"https://github.com/landlab/landlab_teaching_tools/blob/master/README.md\">https://github.com/landlab/landlab_teaching_tools/blob/master/README.md</a></small><br>\n",
     "<small>For tutorials on learning Landlab, click here: <a href=\"https://github.com/landlab/landlab/wiki/Tutorials\">https://github.com/landlab/landlab/wiki/Tutorials</a></small>\n",
     "<hr>"
    ]


### PR DESCRIPTION
@nicgaspar 
This pull request is to:
- update the links in the tutorials to point to tutorials/release (they were pointing to tutorials/master, which won't be updated anymore). It's not a big change here (only for the Landlab logo in the header) but I was doing it throughout the wiki and other tutorials so I thought I would check the teaching tuto as well.
- change the link to README: while doing the above, I noticed you had modified the README.md file in the teaching_tools folder but links in the teaching notebooks were pointing to the README.md in the tutorials folder, so I changed that too.