### PR TITLE
Set up testing notebooks on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ before_install:
 install:
 - conda env create --file=environment.yml
 - source activate landlab_tutorials
+- conda info --all && conda list && conda list landlab
 script:
 - travis_wait 50 pytest -vvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: generic
+os:
+- linux
+sudo: false
+before_install:
+- curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > $HOME/miniconda.sh
+- bash $HOME/miniconda.sh -b -p $HOME/anaconda
+- export PATH="$HOME/anaconda/bin:$PATH"
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+install:
+- conda env create --file=environment.yml
+- source activate landlab_tutorials
+script:
+- travis_wait 50 pytest -vvv

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 [![Landlab header](./landlab_header.png)](http://landlab.github.io)
 
+[![Build Status](https://travis-ci.org/landlab/landlab_teaching_tools.svg?branch=master)](https://travis-ci.org/landlab/landlab_teaching_tools)
+
+
 # Landlab teaching tools :raising_hand:
 
 This repository includes Jupyter Notebooks that implement Landlab for use in teaching undergraduate and graduate courses. Jupyter Notebooks combine formatted text with code that can be run. Students can run small parts of code bit by bit as they follow along with the text.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: landlab_tutorials
+channels:
+  - conda-forge
+dependencies:
+- python==3.7
+- jupyter
+- landlab
+- pytest

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import tempfile
+
+import nbformat
+
+_TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+_EXCLUDE = []
+
+
+def all_notebooks(path="."):
+    notebooks = []
+    for root, dirs, files in os.walk(path):
+        if ".ipynb_checkpoints" in root:
+            continue
+        for file in files:
+            if file.endswith(".ipynb") and (file not in _EXCLUDE):
+                notebooks.append(os.path.join(root, file))
+    return notebooks
+
+
+def pytest_generate_tests(metafunc):
+    if "notebook" in metafunc.fixturenames:
+        metafunc.parametrize("notebook", all_notebooks(_TEST_DIR))
+
+
+def _notebook_run(path):
+    """Execute a notebook via nbconvert and collect output.
+       :returns (parsed nb object, execution errors)
+    """
+    _, notebook = os.path.split(path)
+    base, ext = os.path.splitext(notebook)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".ipynb") as fp:
+        args = [
+            "jupyter",
+            "nbconvert",
+            "--to",
+            "notebook",
+            "--execute",
+            "--ExecutePreprocessor.kernel_name=python",
+            "--ExecutePreprocessor.timeout=None",
+            "--output",
+            fp.name,
+            "--output-dir=.",
+            path,
+        ]
+        subprocess.check_call(args)
+
+        nb = nbformat.read(fp.name, nbformat.current_nbformat, encoding="UTF-8")
+
+    errors = [
+        output
+        for cell in nb.cells
+        if "outputs" in cell
+        for output in cell["outputs"]
+        if output.output_type == "error"
+    ]
+
+    return nb, errors
+
+
+def test_notebook(tmpdir, notebook):
+    with tmpdir.as_cwd():
+        nb, errors = _notebook_run(notebook)
+        assert not errors


### PR DESCRIPTION
This pull request enables continuous integration testing of the notebooks on Travis. Notebooks are only tested to see if they run without error, not if the run correctly. I've only added tests for Python 3.7 on LInux but it wouldn't be all that hard to add additional Python versions or operating systems.